### PR TITLE
01: Soften "vulnerable" to "risky" on dropping braces

### DIFF
--- a/01-introduction-to-java.md
+++ b/01-introduction-to-java.md
@@ -806,8 +806,8 @@ if (classSize > 500)
     System.out.println("Wow, that's big!");
 ```
 
+But this code is risky!  If we added more code, we might indent it nicely and fool ourselves into thinking it's inside the if-block:
 
-But this code is vulnerable!  If we add more code, we may indent it nicely and fool ourselves into thinking it's inside the if-block:
 ```java
 if (classSize > 500)
     System.out.println("Wow, that's big!");


### PR DESCRIPTION
"Vulnerable" has the specific connotation of an exploitable security
bug. While misleading indentation can lead to actual security
vulnerabilities (famously, Apple's gotofail), it is by no means
inherent. The likely effect is also more "buggy" than specifically
vulnerable. As such, soften the wording to say dropping braces is
"risky".

Signed-off-by: Alyssa Rosenzweig <alyssa@rosenzweig.io>