### PR TITLE
Fix spelling and 1.9.1 example

### DIFF
--- a/01-introduction-to-java.md
+++ b/01-introduction-to-java.md
@@ -1068,8 +1068,8 @@ The reason, however, is different. Can you draw the memory model for this code, 
 
 How can we get use a method to change the value of `cost`? In either language, we use the same approach: Return the changed value and in the calling code, assign it to the variable we wished to change. Here it is in Java:
 ```java
-static String increased(String s) {
-    return s + s + "!";    
+static int increased(int i) {
+    return i + 10;
 }
 public static void main(String[] args) {
     int cost = 9;

--- a/01-introduction-to-java.md
+++ b/01-introduction-to-java.md
@@ -240,7 +240,7 @@ This syntax should remind you of how `str` are declared in Python. However, don'
 Strings have various methods available to them. More information on these can be found using the Java API here: https://docs.oracle.com/javase/8/docs/api/java/lang/String.html
 
 ### 1.4.2. Strings are Immutable
-Just as in Python, `String` objects are immutalbe in Java. This means that we can never change a `String` object once it has been created. We *can* perform operations on `String`s, but rather than change an existing `String`, they return a new one.
+Just as in Python, `String` objects are immutable in Java. This means that we can never change a `String` object once it has been created. We *can* perform operations on `String`s, but rather than change an existing `String`, they return a new one.
 
 ### 1.4.3. String Operations and Methods
 `String`s can be concatenated to produce a new `String` object:


### PR DESCRIPTION
Hello! One change is just a small spelling fix, and the other change modifies one of the example snippets. I could be wrong, but I believe that the `increased` example function should accept an `int` instead of a `String`, becuse an `int` is what it's called with in the `main` snippet below. Feel free to adjust the exact implementation if you had something else in mind, or clarify if I'm misunderstanding the example!