### PR TITLE
Add-on when objects are comparable

### DIFF
--- a/02-classes-in-java.md
+++ b/02-classes-in-java.md
@@ -203,7 +203,7 @@ public static void main(String[] args) {
 
 ```
 
-The sort method has another requirement: all elements in the array must be **mutually** comparable. This prevents us from trying to sort an array with a mixture of `DateTime` objects and `File` objects, for instance. These objects are comparable *within* each class, but not *across* classes.
+The sort method has another requirement: all elements in the array must be **mutually** comparable. This prevents us from trying to sort an array with a mixture of `DateTime` objects and `File` objects, for instance. These objects are comparable *within* each class, but not *across* classes (Unless the classes which the objects are instances of share a parent class implementing `Comparable`).
 
 ### 2.8.2. Being comparable enables comparisons
 If we ever wish simply to compare a MonthDay to any other MonthDay, we can do this as well:


### PR DESCRIPTION
If I'm not mistaken, as long as objects share a common parent class implementing Comparable, they will be mutually comparable. The statement not across classes doesn't take that into consideration in my opinion.